### PR TITLE
browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "node": "*"
     }
   , "main": "./index"
+  , "browser": "./lib/concat.js"
   , "scripts": {
       "test": "make test"
     }


### PR DESCRIPTION
without it, it will try and include lib-cov (from the index file)
